### PR TITLE
Fix xkcd tool's second param to be zoid type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export class MyMCP extends McpAgent {
             content: [{ type: "text", text: String(a + b) }],
         }));
 
-        this.server.tool("xkcd", {}, async () => {
+        this.server.tool("xkcd", z.object({ type: z.literal("image"), url: z.string(), alt: z.string() }), async () => {
             const response = await fetch("https://xkcd.com/info.0.json");
             const data = await response.json();
             return {


### PR DESCRIPTION
Update the `xkcd` tool's second parameter to use `zod` for validation.

* Import `z` from `zod`.
* Update the `xkcd` tool's second parameter to use `z.object` for validation.
* Ensure the `xkcd` tool's response structure matches `{ type: "image", url: data.img, alt: data.alt }`.

